### PR TITLE
Add color for visual (column) guide

### DIFF
--- a/Solarized Dark.icls
+++ b/Solarized Dark.icls
@@ -20,6 +20,7 @@
     <option name="SELECTION_BACKGROUND" value="657b83" />
     <option name="SELECTION_FOREGROUND" value="2b36" />
     <option name="TEARLINE_COLOR" value="586e75" />
+    <option name="VISUAL_INDENT_GUIDE" value="73642" />
     <option name="WHITESPACES" value="586e75" />
   </colors>
   <attributes>

--- a/Solarized Light.icls
+++ b/Solarized Light.icls
@@ -20,6 +20,7 @@
     <option name="SELECTION_BACKGROUND" value="839496" />
     <option name="SELECTION_FOREGROUND" value="fdf6e3" />
     <option name="TEARLINE_COLOR" value="93a1a1" />
+    <option name="VISUAL_INDENT_GUIDE" value="eee8d5" />
     <option name="WHITESPACES" value="93a1a1" />
   </colors>
   <attributes>


### PR DESCRIPTION
Without this added setting, IntelliJ uses a harsh fallback color. As of IntelliJ IDEA 2018.1, these guides can be configured via Settings > Editor > Code Style >Visual Guides